### PR TITLE
Switch to upstream goxsys/svc

### DIFF
--- a/service_windows.go
+++ b/service_windows.go
@@ -2,8 +2,8 @@ package service
 
 import (
 	"fmt"
-	"github.com/btcsuite/winsvc/mgr"
-	"github.com/btcsuite/winsvc/svc"
+	"golang.org/x/sys/windows/svc"
+	"golang.org/x/sys/windows/svc/mgr"
 	"gopkg.in/hlandau/easyconfig.v1/cflag"
 	"gopkg.in/hlandau/svcutils.v1/exepath"
 	"os"
@@ -205,7 +205,7 @@ func (info *Info) startService() error {
 	}
 	defer service.Close()
 
-	err = service.Start(os.Args)
+	err = service.Start(os.Args...)
 	if err != nil {
 		return fmt.Errorf("could not start service: %v", err)
 	}


### PR DESCRIPTION
Conformal's fork of goxsys/svc is unmaintained since 2015.  There's no reason to use their fork compared to upstream.

Fixes https://github.com/hlandau/service/issues/14